### PR TITLE
ci(pre-commit): add pre-commit hooks for others to use

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,14 @@
+-   id: generate-toc
+    name: Generate ADR TOC
+    description: Generates a table of contents based on architecture decision register items
+    language: python
+    entry: pyadr toc --no-interaction
+    files: \d{4}-.*\.md$
+    pass_filenames: false
+-   id: check-adr
+    name: Check repository ADR
+    description: Perform sanity checks typically required on ADR files before merging a Pull Request
+    language: python
+    entry: pyadr check-adr-repo --no-interaction
+    files: \d{4}-.*\.md$
+    pass_filenames: false


### PR DESCRIPTION
I'm not 100% sold on the RegEx for files there but I presume the user could configure any directory to hold the ADR Markdown files, so I can't rely on `docs/adr` location. Also of note is that Prettier isn't compatible with the ADR template markdown, I just added it to my `.prettierignore`.

Closes #64 