### PR TITLE
create new ADR from template file if exists

### DIFF
--- a/pyadr/core.py
+++ b/pyadr/core.py
@@ -1,7 +1,6 @@
 import re
 import shutil
 from pathlib import Path
-from tkinter import W
 from typing import List, Optional, Tuple
 
 from loguru import logger

--- a/pyadr/core.py
+++ b/pyadr/core.py
@@ -1,6 +1,7 @@
 import re
 import shutil
 from pathlib import Path
+from tkinter import W
 from typing import List, Optional, Tuple
 
 from loguru import logger
@@ -153,8 +154,14 @@ class AdrCore(object):
         adr_path = Path(self.config["adr"]["records-dir"], f"XXXX-{slugify(title)}.md")
 
         logger.info(f"Creating ADR '{adr_path}'...")
+
+        template = Path(self.config["adr"]["records-dir"], "template.md")
         with adr_path.open("w") as f:
-            f.write(pkg_resources.read_text(assets, "madr-template.md"))  # type: ignore
+            if(template.exists()):
+                with template.open("r") as t:
+                    f.write(t.read())
+            else:
+                f.write(pkg_resources.read_text(assets, "madr-template.md"))  # type: ignore
         update_adr(adr_path, title=title, status=STATUS_PROPOSED)
         logger.log("VERBOSE", "... done.")
 


### PR DESCRIPTION
I noticed that pyadr create a template file when first initialising the config but then never uses it. 

New ADRs are now create from the template file if it exists and otherwise from the build in template. 